### PR TITLE
allow reference to outside images

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <META HTTP-EQUIV='Content-Security-Policy'
-          CONTENT="default-src 'none'; font-src 'none'; img-src 'self' https://static.jboss.org; object-src 'none'; script-src 'self'; style-src 'self' https://static.jboss.org; base-uri 'none'; form-action 'none'; frame-ancestors 'none' "/>
+          CONTENT="default-src 'none'; font-src 'none'; object-src 'none'; script-src 'self'; style-src 'self' https://static.jboss.org; base-uri 'none'; form-action 'none'; frame-ancestors 'none' "/>
     <!--   <META HTTP-EQUIV='X-Frame-Options' CONTENT="DENY"> -->
     <META HTTP-EQUIV='X-XSS-Protection' CONTENT="1; mode=block">
     <META HTTP-EQUIV='X-Content-Type-Options' CONTENT="nosniff">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <META HTTP-EQUIV='Content-Security-Policy'
-          CONTENT="default-src 'none'; font-src 'none'; object-src 'none'; script-src 'self'; style-src 'self' https://static.jboss.org; base-uri 'none'; form-action 'none'; frame-ancestors 'none' "/>
+          CONTENT="default-src 'none'; font-src 'none'; object-src 'none'; script-src 'self'; img-src 'self' https://static.jboss.org https://user-images.githubusercontent.com https://raw.githubusercontent.com; style-src 'self' https://static.jboss.org; base-uri 'none'; form-action 'none'; frame-ancestors 'none' "/>
     <!--   <META HTTP-EQUIV='X-Frame-Options' CONTENT="DENY"> -->
     <META HTTP-EQUIV='X-XSS-Protection' CONTENT="1; mode=block">
     <META HTTP-EQUIV='X-Content-Type-Options' CONTENT="nosniff">


### PR DESCRIPTION
@asoldano @jamezp According to https://content-security-policy.com/ the current setting of our website doesn't allow displaying image link that outside this repository, which makes it inconvenient to add images into blogs (sometimes screenshot is more expressive than text IMHO). But if we put every images of blog into this project, than the size of this project will be expanded quickly. So better put images out of this repo(such as using gist.github.io, etc).

wdyt?